### PR TITLE
Replace "customer" with "customerId" on transaction request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .idea
 /build/
 /fake-bank-service/build/
+/fake-bank-service/out/
 /*.iml
 /out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@ services:
   fake-bank-service:
     image: 'com.pillar/fake-bank-service'
     ports:
-    - "5000:8080"
+      - "5000:8080"

--- a/fake-bank-service/src/main/java/com/pillar/fakeBankService/FakeBankServiceController.java
+++ b/fake-bank-service/src/main/java/com/pillar/fakeBankService/FakeBankServiceController.java
@@ -4,13 +4,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("/api/transaction")
 public class FakeBankServiceController {
     private Double currentBalance = 7000.0;
 
     @RequestMapping(method = {RequestMethod.POST})
-    public ResponseEntity<?> postTransaction(@RequestBody TransactionRequest transaction) {
+    public ResponseEntity<?> postTransaction(@Valid @RequestBody TransactionRequest transaction) {
         if (transaction.getAmount() + currentBalance <= transaction.getCreditLimit()) {
             return new ResponseEntity<>(HttpStatus.CREATED);
         } else {

--- a/fake-bank-service/src/main/java/com/pillar/fakeBankService/TransactionRequest.java
+++ b/fake-bank-service/src/main/java/com/pillar/fakeBankService/TransactionRequest.java
@@ -1,22 +1,64 @@
 package com.pillar.fakeBankService;
 
+import javax.validation.constraints.NotNull;
 import java.util.Date;
 
 public class TransactionRequest {
 
     public TransactionRequest() {}
 
+    public String getCardNumber() {
+        return cardNumber;
+    }
+
+    public void setCardNumber(String cardNumber) {
+        this.cardNumber = cardNumber;
+    }
+
+    @NotNull
     private String cardNumber;
-    private Double amount;
-    private Double creditLimit;
-    private Date dateOfTransaction;
-    private String customer;
 
     public Double getAmount() {
         return amount;
     }
 
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+
+    @NotNull
+    private Double amount;
+
     public Double getCreditLimit() {
         return creditLimit;
     }
+
+    public void setCreditLimit(Double creditLimit) {
+        this.creditLimit = creditLimit;
+    }
+
+    @NotNull
+    private Double creditLimit;
+
+    public Date getDateOfTransaction() {
+        return dateOfTransaction;
+    }
+
+    public void setDateOfTransaction(Date dateOfTransaction) {
+        this.dateOfTransaction = dateOfTransaction;
+    }
+
+    @NotNull
+    private Date dateOfTransaction;
+
+    public Integer getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(Integer customerId) {
+        this.customerId = customerId;
+    }
+
+    @NotNull
+    private Integer customerId;
 }

--- a/src/cucumberTest/java/com/pillar/cucumber/TransactionStepdefs.java
+++ b/src/cucumberTest/java/com/pillar/cucumber/TransactionStepdefs.java
@@ -55,7 +55,7 @@ public class TransactionStepdefs {
         transaction.put("amount", 2.00);
         transaction.put("creditLimit", account.getCreditLimit());
         transaction.put("dateOfTransaction", new Date());
-        transaction.put("customer", "Foobar");
+        transaction.put("customerId", 1);
         response =  fakeServiceClient
                 .post()
                 .uri("/api/transaction")


### PR DESCRIPTION
Alters the fake bank server's interface to accept an int `customerId` field instead of a string `customer` one.